### PR TITLE
Handle host file missing error in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/ccweb-add-on-devcert",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "Generate trusted local SSL/TLS certificates for local SSL development",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -1,12 +1,12 @@
-import createDebug from 'debug';
 import crypto from 'crypto';
-import { writeFileSync as write, readFileSync as read } from 'fs';
+import createDebug from 'debug';
+import { existsSync as exists, readFileSync as read, writeFileSync as write } from 'fs';
 import { sync as rimraf } from 'rimraf';
-import { Options } from '../index';
-import { assertNotTouchingFiles, openCertificateInFirefox } from './shared';
 import { Platform } from '.';
-import { run, sudo } from '../utils';
+import { Options } from '../index';
 import UI from '../user-interface';
+import { run, sudo } from '../utils';
+import { assertNotTouchingFiles, openCertificateInFirefox } from './shared';
 
 const debug = createDebug('devcert:platforms:windows');
 
@@ -56,6 +56,14 @@ export default class WindowsPlatform implements Platform {
   }
 
   async addDomainToHostFileIfMissing(domain: string) {
+    if (!exists(this.HOST_FILE_PATH)) {
+      console.warn(`Could not verify ${domain} entry in the host file.`);
+      console.warn('Please ensure to have:');
+      console.log(`127.0.0.1  ${domain}`);
+      console.warn("entry in your system's host file.");
+      return;
+    }
+
     let hostsFileContents = read(this.HOST_FILE_PATH, 'utf8');
     if (!hostsFileContents.includes(domain)) {
       await sudo(`echo 127.0.0.1  ${ domain } >> ${ this.HOST_FILE_PATH }`);

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -57,7 +57,7 @@ export default class WindowsPlatform implements Platform {
 
   async addDomainToHostFileIfMissing(domain: string) {
     if (!exists(this.HOST_FILE_PATH)) {
-      console.warn(`Could not verify ${domain} entry in the host file.`);
+      console.warn('Could not locate the host file in your system.');
       console.warn('Please ensure to have:');
       console.log(`127.0.0.1  ${domain}`);
       console.warn("entry in your system's host file.");

--- a/src/platforms/win32.ts
+++ b/src/platforms/win32.ts
@@ -1,12 +1,12 @@
-import crypto from 'crypto';
 import createDebug from 'debug';
-import { existsSync as exists, readFileSync as read, writeFileSync as write } from 'fs';
+import crypto from 'crypto';
+import { existsSync as exists, writeFileSync as write, readFileSync as read } from 'fs';
 import { sync as rimraf } from 'rimraf';
-import { Platform } from '.';
 import { Options } from '../index';
-import UI from '../user-interface';
-import { run, sudo } from '../utils';
 import { assertNotTouchingFiles, openCertificateInFirefox } from './shared';
+import { Platform } from '.';
+import { run, sudo } from '../utils';
+import UI from '../user-interface';
 
 const debug = createDebug('devcert:platforms:windows');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handle error when the host file in Windows is missing from its default location:
```
C:\Windows\System32\drivers\etc\hosts
```

Reported issue: https://discord.com/channels/1093561069689110568/1384850404138946711

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
